### PR TITLE
P2022-1276 Change api to require authentication.

### DIFF
--- a/src/main/java/com/intive/patronage22/szczecin/retroboard/configuration/security/WebSecurityConfig.java
+++ b/src/main/java/com/intive/patronage22/szczecin/retroboard/configuration/security/WebSecurityConfig.java
@@ -48,9 +48,8 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     protected void configure(final HttpSecurity http) throws Exception {
         http.csrf().disable();
         http.sessionManagement().sessionCreationPolicy(STATELESS);
-        http.authorizeRequests().antMatchers(URL_REGISTER, URL_LOGIN, "/api/v1/boards/**",
-                "/swagger-ui/**", "/v3/api-docs/**", "/error", "/actuator/health").permitAll();
-        http.authorizeRequests().antMatchers("/private").authenticated();
+        http.authorizeRequests().antMatchers(URL_REGISTER, URL_LOGIN, "/swagger-ui/**", "/v3/api-docs/**",
+                "/error", "/actuator/health").permitAll();
 
         http.addFilter(getCustomAuthenticationFilter());
         http.authorizeRequests().anyRequest().authenticated();

--- a/src/main/java/com/intive/patronage22/szczecin/retroboard/controller/BoardController.java
+++ b/src/main/java/com/intive/patronage22/szczecin/retroboard/controller/BoardController.java
@@ -7,6 +7,7 @@ import com.intive.patronage22.szczecin.retroboard.service.BoardService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
@@ -38,10 +39,10 @@ public class BoardController {
 
     @GetMapping
     @ResponseStatus(OK)
-    @Operation(summary = "Get retro board for given user.",
-               responses = {@ApiResponse(responseCode = "200", description = "OK"),
-                       @ApiResponse(responseCode = "400", description = "Bad request data"),
-                       @ApiResponse(responseCode = "404", description = "User not found")})
+    @Operation(security = @SecurityRequirement(name = "tokenAuth"), summary = "Get retro board for given user.",
+            responses = {@ApiResponse(responseCode = "200", description = "OK"),
+                    @ApiResponse(responseCode = "400", description = "Bad request data"),
+                    @ApiResponse(responseCode = "404", description = "User not found")})
     public List<BoardDto> getUserBoards(final Authentication authentication) {
 
         return boardService.getUserBoards(authentication.getName());
@@ -49,10 +50,10 @@ public class BoardController {
 
     @GetMapping("/{id}")
     @ResponseStatus(OK)
-    @Operation(summary = "Get retro board data for user by id",
-               responses = {@ApiResponse(responseCode = "200", description = "OK"),
-                       @ApiResponse(responseCode = "400", description = "User has no access to board."),
-                       @ApiResponse(responseCode = "404", description = "Board is not found")})
+    @Operation(security = @SecurityRequirement(name = "tokenAuth"), summary = "Get retro board data for user by id",
+            responses = {@ApiResponse(responseCode = "200", description = "OK"),
+                    @ApiResponse(responseCode = "400", description = "User has no access to board."),
+                    @ApiResponse(responseCode = "404", description = "Board is not found")})
     public BoardDataDto getBoardDataById(@PathVariable final Integer id, final Authentication authentication) {
 
         return boardService.getBoardDataById(id, authentication.getName());
@@ -60,7 +61,7 @@ public class BoardController {
 
     @PostMapping
     @ResponseStatus(CREATED)
-    @Operation(summary = "Create retro board for given user.",
+    @Operation(security = @SecurityRequirement(name = "tokenAuth"), summary = "Create retro board for given user.",
             responses = {@ApiResponse(responseCode = "201", description = "Board created for given user"),
                     @ApiResponse(responseCode = "400", description = "User not found"),
                     @ApiResponse(responseCode = "400", description = "Board name not valid")})
@@ -72,7 +73,7 @@ public class BoardController {
 
     @DeleteMapping("/{id}")
     @ResponseStatus(OK)
-    @Operation(summary = "Delete retro board for given id.",
+    @Operation(security = @SecurityRequirement(name = "tokenAuth"), summary = "Delete retro board for given id.",
             responses = {@ApiResponse(responseCode = "200", description = "Board deleted for given user"),
                     @ApiResponse(responseCode = "400", description = "User is not the board owner"),
                     @ApiResponse(responseCode = "404", description = "Board not found")})
@@ -83,7 +84,7 @@ public class BoardController {
     }
 
     @PatchMapping("/{id}")
-    @Operation(summary = "Update board name and number of votes")
+    @Operation(security = @SecurityRequirement(name = "tokenAuth"), summary = "Update board name and number of votes")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "OK"),
             @ApiResponse(responseCode = "400", description = "Bad request data"),

--- a/src/main/java/com/intive/patronage22/szczecin/retroboard/controller/UserController.java
+++ b/src/main/java/com/intive/patronage22/szczecin/retroboard/controller/UserController.java
@@ -4,15 +4,11 @@ import com.google.firebase.auth.FirebaseAuthException;
 import com.intive.patronage22.szczecin.retroboard.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -34,12 +30,6 @@ import static org.springframework.http.HttpStatus.CREATED;
 public class UserController {
 
     private final UserService userService;
-
-    @GetMapping("/private")
-    @Operation(security = @SecurityRequirement(name = "tokenAuth"))
-    Authentication privateOp() {
-        return SecurityContextHolder.getContext().getAuthentication();
-    }
 
     @PostMapping(value = "/register")
     @ResponseStatus(CREATED)

--- a/src/test/java/com/intive/patronage22/szczecin/retroboard/controller/UserControllerTest.java
+++ b/src/test/java/com/intive/patronage22/szczecin/retroboard/controller/UserControllerTest.java
@@ -1,8 +1,6 @@
 package com.intive.patronage22.szczecin.retroboard.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.firebase.auth.FirebaseAuth;
-import com.google.firebase.auth.FirebaseToken;
 import com.intive.patronage22.szczecin.retroboard.configuration.security.SecurityConfig;
 import com.intive.patronage22.szczecin.retroboard.exception.MissingFieldException;
 import com.intive.patronage22.szczecin.retroboard.exception.UserAlreadyExistException;
@@ -14,7 +12,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpMethod;
@@ -41,15 +38,16 @@ import static com.intive.patronage22.szczecin.retroboard.configuration.security.
 import static com.intive.patronage22.szczecin.retroboard.configuration.security.WebSecurityConfig.URL_REGISTER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withBadRequest;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @RunWith(SpringRunner.class)
 @WebMvcTest({UserController.class, SecurityConfig.class})
@@ -359,41 +357,5 @@ class UserControllerTest {
                         .contentType(MediaType.APPLICATION_FORM_URLENCODED))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.error_message").value("Missing password."));
-    }
-
-    @Test
-    void privateShouldReturnForbiddenWhenUserNotLoggedin() throws Exception {
-        // given
-        final String url = "/api/v1/private";
-
-        // then
-        mockMvc
-                .perform(get(url).contentType(MediaType.APPLICATION_FORM_URLENCODED))
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isForbidden())
-                .andExpect(jsonPath("$.error_message").value("Access Denied"));
-    }
-
-    @Test
-    void privateShouldReturnOkWhenUserAuthenticated() throws Exception {
-        // given
-        final String url = "/api/v1/private";
-        final String email = "test22@test.com";
-        final String providedAccessToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9." +
-                "eyJzdWIiOiJzb21ldXNlciIsInJvbGVzIjpbIlJPTEVfVVNFUiJdLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvbG9na" +
-                "W4ifQ.vDeQLA7Y8zTXaJW8bF08lkWzzwGi9Ll44HeMbOc22_o";
-
-        final FirebaseToken firebaseToken = mock(FirebaseToken.class);
-
-        // when
-        when(firebaseToken.getEmail()).thenReturn(email);
-        when(firebaseAuth.verifyIdToken(providedAccessToken)).thenReturn(firebaseToken);
-
-        // then
-        mockMvc
-                .perform(get(url).header(AUTHORIZATION, "Bearer " + providedAccessToken))
-                .andExpect(jsonPath("$.name").value("test22@test.com"))
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk());
     }
 }


### PR DESCRIPTION
- From now on only "/register","/login", "/swagger-ui/{}", "/v3/api-docs/{}" , "/error", "/actuator/health" are public. Other endpoints require authentication
- Endpoints that require authentication have padlock icon next to them in swagger
- Removed "/private" and tests associated with it

