### PR TITLE
P2022-1431 When incorrect email provided login return status 500

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,11 @@
             <version>5.8.1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>commons-validator</groupId>
+            <artifactId>commons-validator</artifactId>
+            <version>1.7</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/intive/patronage22/szczecin/retroboard/exception/EmailFormatException.java
+++ b/src/main/java/com/intive/patronage22/szczecin/retroboard/exception/EmailFormatException.java
@@ -1,0 +1,10 @@
+package com.intive.patronage22.szczecin.retroboard.exception;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class EmailFormatException extends AuthenticationException {
+
+    public EmailFormatException(final String msg) {
+        super(msg);
+    }
+}

--- a/src/test/java/com/intive/patronage22/szczecin/retroboard/controller/UserControllerTest.java
+++ b/src/test/java/com/intive/patronage22/szczecin/retroboard/controller/UserControllerTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -252,40 +253,36 @@ class UserControllerTest {
                 .andExpect(jsonPath("$.error_message").value("Email not found."));
     }
 
-    @Test
-    void loginShouldReturnBadRequestWhenEmailIsMissing() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"test", "t@e.p", "123@", "test@o2.", "test@o2.l", "", " "})
+    void loginShouldReturnBadRequestWhenEmailIsInvalid(final String email) throws Exception {
         // given
-        final String email = null;
         final String password = "1234";
-        final MissingFieldException expectedException = new MissingFieldException("Missing email.");
-        final UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(email, password);
-        firebaseRestServiceServer.expect(method(HttpMethod.POST))
-                .andRespond(withBadRequest()
-                        .body("{\n" +
-                                "  \"error\": {\n" +
-                                "    \"code\": 400,\n" +
-                                "    \"message\": \"MISSING_EMAIL\",\n" +
-                                "    \"errors\": [\n" +
-                                "      {\n" +
-                                "        \"message\": \"MISSING_EMAIL\",\n" +
-                                "        \"domain\": \"global\",\n" +
-                                "        \"reason\": \"invalid\"\n" +
-                                "      }\n" +
-                                "    ]\n" +
-                                "  }\n" +
-                                "}").contentType(MediaType.APPLICATION_JSON));
 
-        // when
-        when(authenticationManager.authenticate(token)).thenThrow(expectedException);
-
-        // then
+        // when then
         mockMvc
                 .perform(post(URL_LOGIN)
                         .param("email", email)
                         .param("password", password)
                         .contentType(MediaType.APPLICATION_FORM_URLENCODED))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error_message").value("Missing email."));
+                .andExpect(jsonPath("$.error_message").value("Invalid email."));
+    }
+
+    @Test
+    void loginShouldReturnBadRequestWhenEmailIsNull() throws Exception {
+        // given
+        final String email = null;
+        final String password = "1234";
+
+        // when then
+        mockMvc
+                .perform(post(URL_LOGIN)
+                        .param("email", email)
+                        .param("password", password)
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error_message").value("Invalid email."));
     }
 
     @Test


### PR DESCRIPTION
This PR should fix bug P2022-1431 - When incorrect email provided login return status 500

- added Apache Commons Validator for Email ( https://www.baeldung.com/java-email-validation-regex#11-apache-commons-validator-for-email )
- deleted one condition checking if email is blank or null, EmailValidator covers it
- added EmailFormatException
- added new test 