### PR TITLE
P2022-1710, P2022-1711 bug fix removeUserAssignedToTheBoard

### DIFF
--- a/src/main/java/com/intive/patronage22/szczecin/retroboard/service/BoardService.java
+++ b/src/main/java/com/intive/patronage22/szczecin/retroboard/service/BoardService.java
@@ -199,16 +199,18 @@ public class BoardService {
 
         final User user = userRepository.findById(uid)
                 .orElseThrow(() -> new NotFoundException("User is not found"));
+        
         final Board board = boardRepository.findById(boardId)
                 .orElseThrow(() -> new NotFoundException("Board is not found"));
+
+        if (board.getCreator().equals(user)) {
+            throw new BadRequestException("User is the board owner.");
+        }
 
         if (!board.getUsers().contains(user)) {
             throw new BadRequestException("User is not assigned to the Board.");
         }
 
-        if (board.getCreator().equals(user)) {
-            throw new BadRequestException("User is the board owner.");
-        }
         if (email.equals(user.getEmail()) || email.equals(board.getCreator().getEmail())) {
             board.getUsers().remove(user);
         } else {

--- a/src/main/java/com/intive/patronage22/szczecin/retroboard/service/BoardService.java
+++ b/src/main/java/com/intive/patronage22/szczecin/retroboard/service/BoardService.java
@@ -202,6 +202,10 @@ public class BoardService {
         final Board board = boardRepository.findById(boardId)
                 .orElseThrow(() -> new NotFoundException("Board is not found"));
 
+        if (!board.getUsers().contains(user)) {
+            throw new BadRequestException("User is not assigned to the Board.");
+        }
+
         if (board.getCreator().equals(user)) {
             throw new BadRequestException("User is the board owner.");
         }

--- a/src/test/java/com/intive/patronage22/szczecin/retroboard/service/BoardServiceTest.java
+++ b/src/test/java/com/intive/patronage22/szczecin/retroboard/service/BoardServiceTest.java
@@ -739,6 +739,50 @@ class BoardServiceTest {
     }
 
     @Test
+    void removeAssignedUserShouldThrowBadRequestWhenBoardOwnerTriesToRemoveUserNotAssignedToTheBoard() {
+        // given
+        final String uid = "12345";
+        final String email = "boardOwner@test.pl";
+        final Integer boardId = 1;
+
+        final User notAssignedUser = new User("12345", "test@test.com", "some_user", Set.of(), Set.of());
+        final User boardOwner = new User("123", "boardOwner@test.pl", "board_owner", Set.of(), Set.of());
+        final Board board = buildBoard(boardOwner, EnumStateDto.CREATED, 1, Set.of());
+
+        // when
+        when(userRepository.findById(uid)).thenReturn(Optional.of(notAssignedUser));
+        when(boardRepository.findById(boardId)).thenReturn(Optional.of(board));
+
+        // then
+        final BadRequestException exception = assertThrows(
+                BadRequestException.class, () -> boardService.removeUserAssignedToTheBoard(uid, boardId, email));
+
+        assertEquals("User is not assigned to the Board.", exception.getMessage());
+    }
+
+    @Test
+    void removeAssignedUserShouldThrowBadRequestWhenUserTriesToRemoveHimselfAndHeIsNotAssignedToTheBoard() {
+        // given
+        final String uid = "12345";
+        final String email = "someUser@test.pl";
+        final Integer boardId = 1;
+
+        final User notAssignedUser = new User("12345", "someUser@test.pl", "some_user", Set.of(), Set.of());
+        final User boardOwner = new User("123", "boardOwner@test.pl", "board_owner", Set.of(), Set.of());
+        final Board board = buildBoard(boardOwner, EnumStateDto.CREATED, 1, Set.of());
+
+        // when
+        when(userRepository.findById(uid)).thenReturn(Optional.of(notAssignedUser));
+        when(boardRepository.findById(boardId)).thenReturn(Optional.of(board));
+
+        // then
+        final BadRequestException exception = assertThrows(
+                BadRequestException.class, () -> boardService.removeUserAssignedToTheBoard(uid, boardId, email));
+
+        assertEquals("User is not assigned to the Board.", exception.getMessage());
+    }
+
+    @Test
     @DisplayName("Remove assigned user should throw NotFound when user not exists")
     void removeAssignedUserShouldThrowNotFoundWhenUserNotExists() {
         //given


### PR DESCRIPTION
This PR should fix bugs [P2022-1711](https://tracker.intive.com/jira/browse/P2022-1711) and [P2022-1710](https://tracker.intive.com/jira/browse/P2022-1710)

Issues:

1. ` Board creator` could remove `User` not assigned to the `Board`
2.  `User` could remove himself when he is not assigned to the `Board`
