### PR TITLE
P2022-1883 Full synchronization of firebase users.

### DIFF
--- a/src/main/java/com/intive/patronage22/szczecin/retroboard/filter/CustomAuthorizationFilter.java
+++ b/src/main/java/com/intive/patronage22/szczecin/retroboard/filter/CustomAuthorizationFilter.java
@@ -49,7 +49,7 @@ public class CustomAuthorizationFilter extends OncePerRequestFilter {
 
             if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
                 try {
-                    final String token = authorizationHeader.substring("Bearer ".length());
+                    final String token = authorizationHeader.substring("Bearer " .length());
                     final FirebaseToken firebaseToken = firebaseAuth.verifyIdToken(token);
 
                     final var authenticationToken =
@@ -58,13 +58,15 @@ public class CustomAuthorizationFilter extends OncePerRequestFilter {
                                     null,
                                     new HashSet<>());
 
+                    firebaseAuth.getUserByEmail(authenticationToken.getName());
+
                     final Optional<User> optionalUser = userRepository.findUserByEmail(firebaseToken.getEmail());
 
-                    if(optionalUser.isEmpty()){
+                    if (optionalUser.isEmpty()) {
                         final User user = new User(firebaseToken.getUid(),
                                 firebaseToken.getEmail(), firebaseToken.getName(), false, Set.of(), Set.of());
                         userRepository.save(user);
-                        log.info("{} added to database",firebaseToken.getEmail());
+                        log.info("{} added to database", firebaseToken.getEmail());
                     }
 
                     SecurityContextHolder.getContext().setAuthentication(authenticationToken);

--- a/src/main/java/com/intive/patronage22/szczecin/retroboard/filter/CustomAuthorizationFilter.java
+++ b/src/main/java/com/intive/patronage22/szczecin/retroboard/filter/CustomAuthorizationFilter.java
@@ -18,9 +18,12 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.*;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
 
-import static com.intive.patronage22.szczecin.retroboard.configuration.security.WebSecurityConfig.*;
+import static com.intive.patronage22.szczecin.retroboard.configuration.security.WebSecurityConfig.URL_LOGIN;
+import static com.intive.patronage22.szczecin.retroboard.configuration.security.WebSecurityConfig.URL_REGISTER;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
@@ -59,7 +62,7 @@ public class CustomAuthorizationFilter extends OncePerRequestFilter {
 
                     if(optionalUser.isEmpty()){
                         final User user = new User(firebaseToken.getUid(),
-                                firebaseToken.getEmail(), firebaseToken.getName(), Set.of(), Set.of());
+                                firebaseToken.getEmail(), firebaseToken.getName(), false, Set.of(), Set.of());
                         userRepository.save(user);
                         log.info("{} added to database",firebaseToken.getEmail());
                     }

--- a/src/main/java/com/intive/patronage22/szczecin/retroboard/model/User.java
+++ b/src/main/java/com/intive/patronage22/szczecin/retroboard/model/User.java
@@ -6,7 +6,12 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.ManyToMany;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
 import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
@@ -28,6 +33,9 @@ public class User implements Serializable {
 
     @Column(name = "display_name", length = 64)
     private String displayName;
+
+    @Column(name = "deleted")
+    private boolean deleted;
 
     @ManyToMany(mappedBy = "users")
     private Set<Board> userBoards = new HashSet<>();

--- a/src/main/java/com/intive/patronage22/szczecin/retroboard/repository/UserRepository.java
+++ b/src/main/java/com/intive/patronage22/szczecin/retroboard/repository/UserRepository.java
@@ -15,6 +15,11 @@ public interface UserRepository extends CrudRepository<User, String> {
 
     List<User> findAllByEmailIn(List<String> emails);
 
+    @Query("SELECT u FROM User u WHERE u.email IN :emails AND u.deleted IS NOT TRUE")
+    List<User> findAllNotDeactivatedByEmailIn(List<String> emails);
+
+    List<User> findAllByEmailNotIn(List<String> emails);
+
     @Query("SELECT u.email FROM User u WHERE u.email LIKE %:email%")
     List<String> searchByEmailLike(final String email);
 }

--- a/src/main/java/com/intive/patronage22/szczecin/retroboard/service/BoardService.java
+++ b/src/main/java/com/intive/patronage22/szczecin/retroboard/service/BoardService.java
@@ -1,6 +1,14 @@
 package com.intive.patronage22.szczecin.retroboard.service;
 
-import com.intive.patronage22.szczecin.retroboard.dto.*;
+import com.intive.patronage22.szczecin.retroboard.dto.BoardCardDto;
+import com.intive.patronage22.szczecin.retroboard.dto.BoardCardsColumn;
+import com.intive.patronage22.szczecin.retroboard.dto.BoardCardsColumnDto;
+import com.intive.patronage22.szczecin.retroboard.dto.BoardDataDto;
+import com.intive.patronage22.szczecin.retroboard.dto.BoardDetailsDto;
+import com.intive.patronage22.szczecin.retroboard.dto.BoardDto;
+import com.intive.patronage22.szczecin.retroboard.dto.BoardPatchDto;
+import com.intive.patronage22.szczecin.retroboard.dto.EnumStateDto;
+import com.intive.patronage22.szczecin.retroboard.dto.UserDto;
 import com.intive.patronage22.szczecin.retroboard.exception.BadRequestException;
 import com.intive.patronage22.szczecin.retroboard.exception.NotAcceptableException;
 import com.intive.patronage22.szczecin.retroboard.exception.NotFoundException;
@@ -172,7 +180,7 @@ public class BoardService {
             throw new BadRequestException("User is not the board owner.");
         }
 
-        final List<User> users = userRepository.findAllByEmailIn(emailsToAssign);
+        final List<User> users = userRepository.findAllNotDeactivatedByEmailIn(emailsToAssign);
 
         board.getUsers().addAll(users);
         boardRepository.save(board);

--- a/src/main/java/com/intive/patronage22/szczecin/retroboard/service/SynchronizeWithFirebaseScheduler.java
+++ b/src/main/java/com/intive/patronage22/szczecin/retroboard/service/SynchronizeWithFirebaseScheduler.java
@@ -4,15 +4,21 @@ import com.google.firebase.auth.ExportedUserRecord;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseAuthException;
 import com.google.firebase.auth.UserRecord;
+import com.intive.patronage22.szczecin.retroboard.model.Board;
 import com.intive.patronage22.szczecin.retroboard.model.User;
+import com.intive.patronage22.szczecin.retroboard.repository.BoardRepository;
 import com.intive.patronage22.szczecin.retroboard.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -23,9 +29,11 @@ import java.util.stream.StreamSupport;
 public class SynchronizeWithFirebaseScheduler {
 
     private final UserRepository userRepository;
+    private final BoardRepository boardRepository;
     private final FirebaseAuth firebaseAuth;
 
     @Scheduled(fixedRate = 900000, initialDelay = 60000)
+    @Transactional
     public void synchronizeUsers() throws FirebaseAuthException {
         log.info("starting the job");
 
@@ -33,32 +41,78 @@ public class SynchronizeWithFirebaseScheduler {
                 .listUsers(null, 20)
                 .iterateAll();
 
-        final List<ExportedUserRecord> notSignedInUsersFirebase = StreamSupport
+        final List<ExportedUserRecord> allFirebaseUsers = StreamSupport
                 .stream(pagination.spliterator(), false)
-                .filter(u -> u.getUserMetadata().getLastSignInTimestamp() == 0)
                 .collect(Collectors.toList());
 
-        final List<String> notSignedInUsersEmails = notSignedInUsersFirebase.stream()
+        final List<String> firebaseUsersEmails = allFirebaseUsers.stream()
                 .map(UserRecord::getEmail)
                 .collect(Collectors.toList());
 
-        final List<String> alreadyExistingEmails = userRepository.findAllByEmailIn(notSignedInUsersEmails)
+        final List<String> alreadyExistingEmails = userRepository.findAllByEmailIn(firebaseUsersEmails)
                 .stream()
                 .map(User::getEmail)
                 .collect(Collectors.toList());
 
-        final List<User> firebaseUsersToCreate = notSignedInUsersFirebase.stream()
+        final List<User> firebaseUsersToCreate = allFirebaseUsers.stream()
                 .filter(u -> !alreadyExistingEmails.contains(u.getEmail()))
                 .map(u -> User.builder()
                         .email(u.getEmail())
                         .displayName(u.getDisplayName())
                         .uid(u.getUid())
+                        .deleted(false)
                         .build())
                 .collect(Collectors.toList());
 
         final List<User> createdUsers = (List<User>) userRepository.saveAll(firebaseUsersToCreate);
 
         log.info("created users count: {}", createdUsers.size());
+
+        final Predicate<User> canUserBeDeleted = u -> u.getUserBoards().isEmpty();
+
+        final Map<Boolean, List<User>> usersPartition = userRepository.findAllByEmailNotIn(firebaseUsersEmails)
+                .stream()
+                .collect(Collectors.partitioningBy(canUserBeDeleted));
+
+        final List<User> usersToDeleteInDb = usersPartition.get(true);
+        final List<User> usersToDeactivateInDb = usersPartition.get(false);
+
+        deleteUsersByEmail(usersToDeleteInDb);
+        deactivateUsersByEmail(usersToDeactivateInDb);
+
         log.info("finishing the job");
+    }
+
+    @Transactional
+    private void deleteUsersByEmail(final List<User> usersToDelete) {
+        log.info("delete users");
+
+        deleteBoardsCreatedByUsers(usersToDelete);
+        userRepository.deleteAll(usersToDelete);
+
+        log.info("deleted users count: {}", usersToDelete.size());
+    }
+
+    @Transactional
+    private void deactivateUsersByEmail(final List<User> usersToDeactivate) {
+        log.info("deactivate users");
+
+        deleteBoardsCreatedByUsers(usersToDeactivate);
+        usersToDeactivate.forEach(u -> u.setDeleted(true));
+        userRepository.saveAll(usersToDeactivate);
+
+        log.info("deactivated users count: {}", usersToDeactivate.size());
+    }
+
+    @Transactional
+    private void deleteBoardsCreatedByUsers(final List<User> users) {
+        final List<Board> boardsToDelete = users.stream()
+                .map(User::getCreatedBoards)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
+
+        boardRepository.deleteAll(boardsToDelete);
+
+        log.info("deleted boards count: {}", boardsToDelete.size());
     }
 }

--- a/src/main/resources/db/migration/V6_0__user_data.sql
+++ b/src/main/resources/db/migration/V6_0__user_data.sql
@@ -1,0 +1,1 @@
+ALTER TABLE retro.user_data ADD COLUMN deleted boolean default false;

--- a/src/test/java/com/intive/patronage22/szczecin/retroboard/service/BoardCardServiceTest.java
+++ b/src/test/java/com/intive/patronage22/szczecin/retroboard/service/BoardCardServiceTest.java
@@ -37,7 +37,6 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.verify;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
@@ -81,7 +80,7 @@ class BoardCardServiceTest {
                 .build();
         final String email = "test22@test.com";
         final String uid = "1234";
-        final User user = new User(uid, email, "john14", Set.of(), Set.of());
+        final User user = new User(uid, email, "john14", false, Set.of(), Set.of());
         final Board board = buildBoard(boardId, EnumStateDto.CREATED, 5, user, Set.of(), Set.of());
 
         //when
@@ -135,7 +134,7 @@ class BoardCardServiceTest {
                 .build();
         final String email = "test22@test.com";
         final String uid = "1234";
-        final User user = new User(uid, email, "john14", Set.of(), Set.of());
+        final User user = new User(uid, email, "john14", false, Set.of(), Set.of());
 
         //when
         when(userRepository.findUserByEmail(email)).thenReturn(Optional.of(user));
@@ -156,7 +155,7 @@ class BoardCardServiceTest {
                 .build();
         final String email = "test22@test.com";
         final String uid = "1234";
-        final User user = new User(uid, email, "john14", Set.of(), Set.of());
+        final User user = new User(uid, email, "john14", false, Set.of(), Set.of());
 
         //when
         when(userRepository.findUserByEmail(email)).thenReturn(Optional.of(user));
@@ -178,7 +177,7 @@ class BoardCardServiceTest {
                 .build();
         final String email = "test22@test.com";
         final String uid = "1234";
-        final User user = new User(uid, email, "john14", Set.of(), Set.of());
+        final User user = new User(uid, email, "john14", false, Set.of(), Set.of());
         final Board board = buildBoard(boardId, EnumStateDto.VOTING, 5, user, Set.of(), Set.of());
 
         //when
@@ -195,8 +194,8 @@ class BoardCardServiceTest {
         // given
         final Integer cardId = 1;
         final String email = "test22@test.com";
-        final User user = new User("1234", email, "john14", Set.of(), Set.of());
-        final User boardOwner = new User("12345", "some@test.com", "test", Set.of(), Set.of());
+        final User user = new User("1234", email, "john14", false, Set.of(), Set.of());
+        final User boardOwner = new User("12345", "some@test.com", "test", false, Set.of(), Set.of());
         final Board board = buildBoard(1, EnumStateDto.CREATED, 5, boardOwner, Set.of(), Set.of());
         final BoardCard boardCard = buildBoardCard(cardId, board, BoardCardsColumn.SUCCESS, user, List.of());
 
@@ -214,8 +213,8 @@ class BoardCardServiceTest {
         // given
         final Integer cardId = 1;
         final String email = "test22@test.com";
-        final User boardOwner = new User("1234", email, "john14", Set.of(), Set.of());
-        final User user = new User("12345", "some@test.com", "test", Set.of(), Set.of());
+        final User boardOwner = new User("1234", email, "john14", false, Set.of(), Set.of());
+        final User user = new User("12345", "some@test.com", "test", false, Set.of(), Set.of());
         final Board board = buildBoard(1, EnumStateDto.CREATED, 5, boardOwner, Set.of(), Set.of());
         final BoardCard boardCard = buildBoardCard(cardId, board, BoardCardsColumn.SUCCESS, user, List.of());
 
@@ -233,8 +232,8 @@ class BoardCardServiceTest {
         // given
         final Integer cardId = 1;
         final String email = "test22@test.com";
-        final User user = new User("1234", email, "john14", Set.of(), Set.of());
-        final User boardOwner = new User("12345", "some@test.com", "test", Set.of(), Set.of());
+        final User user = new User("1234", email, "john14", false, Set.of(), Set.of());
+        final User boardOwner = new User("12345", "some@test.com", "test", false, Set.of(), Set.of());
         final Board board = buildBoard(1, EnumStateDto.VOTING, 5, boardOwner, Set.of(), Set.of());
         final BoardCard boardCard = buildBoardCard(cardId, board, BoardCardsColumn.SUCCESS, user, List.of());
 
@@ -251,8 +250,8 @@ class BoardCardServiceTest {
         // given
         final Integer cardId = 1;
         final String email = "test22@test.com";
-        final User user = new User("1234", email, "john14", Set.of(), Set.of());
-        final User owner = new User("12345", "some@test.com", "test", Set.of(), Set.of());
+        final User user = new User("1234", email, "john14", false, Set.of(), Set.of());
+        final User owner = new User("12345", "some@test.com", "test", false, Set.of(), Set.of());
         final Board board = buildBoard(1, EnumStateDto.CREATED, 5, owner, Set.of(), Set.of());
         final BoardCard boardCard = buildBoardCard(cardId, board, BoardCardsColumn.SUCCESS, owner, List.of());
 
@@ -270,7 +269,7 @@ class BoardCardServiceTest {
         final Integer cardId = 1;
         final String email = "test22@test.com";
         final String uid = "1234";
-        final User user = new User(uid, email, "john14", Set.of(), Set.of());
+        final User user = new User(uid, email, "john14", false, Set.of(), Set.of());
 
         //when
         when(userRepository.findUserByEmail(email)).thenReturn(Optional.of(user));
@@ -303,7 +302,7 @@ class BoardCardServiceTest {
         // given
         final Integer cardId = 1;
         final String email = "test@example.com";
-        final User user = new User("1234", email, "somename", Set.of(), Set.of());
+        final User user = new User("1234", email, "somename", false, Set.of(), Set.of());
         final String expectedExceptionMessage = "Card not found";
 
         //when
@@ -322,7 +321,7 @@ class BoardCardServiceTest {
         // given
         final Integer cardId = 1;
         final String email = "test@example.com";
-        final User user = new User("1234", email, "somename", Set.of(), Set.of());
+        final User user = new User("1234", email, "somename", false, Set.of(), Set.of());
         final Board board = buildBoard(2, EnumStateDto.CREATED, 5, user, Set.of(), Set.of());
         final BoardCard card = buildBoardCard(cardId, board, BoardCardsColumn.SUCCESS, user, List.of());
         final String expectedExceptionMessage = "Board not exist";
@@ -344,8 +343,8 @@ class BoardCardServiceTest {
         // given
         final Integer cardId = 1;
         final String email = "test@example.com";
-        final User creator = new User("123", "some@example.com", "somename", Set.of(), Set.of());
-        final User user = new User("1234", email, "somename", Set.of(), Set.of());
+        final User creator = new User("123", "some@example.com", "somename", false, Set.of(), Set.of());
+        final User user = new User("1234", email, "somename", false, Set.of(), Set.of());
         final Board board = buildBoard(2, EnumStateDto.CREATED, 5, creator, Set.of(), Set.of());
         final BoardCard card = buildBoardCard(cardId, board, BoardCardsColumn.SUCCESS, creator, List.of());
         final String expectedExceptionMessage = "User not assigned to board";
@@ -367,7 +366,7 @@ class BoardCardServiceTest {
         // given
         final Integer cardId = 1;
         final String email = "test@example.com";
-        final User user = new User("1234", email, "somename", Set.of(), Set.of());
+        final User user = new User("1234", email, "somename", false, Set.of(), Set.of());
         final Board board = buildBoard(2, EnumStateDto.CREATED, 5, user, Set.of(user), new HashSet<>());
         final BoardCard card = buildBoardCard(cardId, board, BoardCardsColumn.SUCCESS, user, List.of());
         board.setBoardCards(Set.of(card));
@@ -390,7 +389,7 @@ class BoardCardServiceTest {
         // given
         final Integer cardId = 1;
         final String email = "test@example.com";
-        final User user = new User("1234", email, "somename", Set.of(), Set.of());
+        final User user = new User("1234", email, "somename", false, Set.of(), Set.of());
         final Board board = buildBoard(2, EnumStateDto.VOTING, 5, user, Set.of(user), new HashSet<>());
         final BoardCard card = buildBoardCard(cardId, board, BoardCardsColumn.SUCCESS, user, List.of());
         board.setBoardCards(Set.of(card));
@@ -417,7 +416,7 @@ class BoardCardServiceTest {
         // given
         final Integer cardId = 1;
         final String email = "test@example.com";
-        final User user = new User("1234", email, "somename", Set.of(), Set.of());
+        final User user = new User("1234", email, "somename", false, Set.of(), Set.of());
         final Board board = buildBoard(2, EnumStateDto.VOTING, 5, user, Set.of(user), new HashSet<>());
         final BoardCard card = buildBoardCard(cardId, board, BoardCardsColumn.SUCCESS, user, List.of());
         board.setBoardCards(Set.of(card));
@@ -445,7 +444,7 @@ class BoardCardServiceTest {
         // given
         final Integer cardId = 1;
         final String email = "test@example.com";
-        final User user = new User("1234", email, "somename", Set.of(), Set.of());
+        final User user = new User("1234", email, "somename", false, Set.of(), Set.of());
         final Board board = buildBoard(2, EnumStateDto.VOTING, 10, user, Set.of(user), new HashSet<>());
         final BoardCard card = buildBoardCard(cardId, board, BoardCardsColumn.FAILURES, user, List.of());
         board.setBoardCards(Set.of(card));
@@ -476,8 +475,8 @@ class BoardCardServiceTest {
         final Integer cardId = 1;
         final String email = "test@example.com";
         final String fakeEmail = "fakeTest@example.com";
-        final User user = new User("1234", email, "somename", Set.of(), Set.of());
-        final User fakeUser = new User("5678", fakeEmail, "somename", Set.of(), Set.of());
+        final User user = new User("1234", email, "somename", false, Set.of(), Set.of());
+        final User fakeUser = new User("5678", fakeEmail, "somename", false, Set.of(), Set.of());
         final Board board = buildBoard(2, EnumStateDto.VOTING, 10, user, Set.of(user), new HashSet<>());
         final BoardCard card = buildBoardCard(cardId, board, BoardCardsColumn.FAILURES, user, List.of());
         board.setBoardCards(Set.of(card));
@@ -498,7 +497,7 @@ class BoardCardServiceTest {
         // given
         final Integer cardId = 1;
         final String email = "test@example.com";
-        final User user = new User("1234", email, "somename", Set.of(), Set.of());
+        final User user = new User("1234", email, "somename", false, Set.of(), Set.of());
         final Board board = buildBoard(2, EnumStateDto.VOTING, 10, user, Set.of(user), new HashSet<>());
         final BoardCard card = buildBoardCard(cardId, board, BoardCardsColumn.FAILURES, user, List.of());
         board.setBoardCards(Set.of(card));
@@ -519,7 +518,7 @@ class BoardCardServiceTest {
         // given
         final Integer cardId = 1;
         final String email = "test@example.com";
-        final User user = new User("1234", email, "somename", Set.of(), Set.of());
+        final User user = new User("1234", email, "somename", false, Set.of(), Set.of());
         final Board board = buildBoard(2, EnumStateDto.CREATED, 10, user, Set.of(user), new HashSet<>());
         final BoardCard card = buildBoardCard(cardId, board, BoardCardsColumn.FAILURES, user, List.of());
         board.setBoardCards(Set.of(card));
@@ -540,7 +539,7 @@ class BoardCardServiceTest {
         // given
         final Integer cardId = 1;
         final String email = "test@example.com";
-        final User user = new User("1234", email, "somename", Set.of(), Set.of());
+        final User user = new User("1234", email, "somename", false, Set.of(), Set.of());
         final Board board = buildBoard(2, EnumStateDto.VOTING, 2, user, Set.of(user), new HashSet<>());
         final BoardCard card = buildBoardCard(cardId, board, BoardCardsColumn.FAILURES, user, List.of());
         board.setBoardCards(Set.of(card));
@@ -561,7 +560,7 @@ class BoardCardServiceTest {
         // given
         final Integer cardId = 1;
         final String email = "test@example.com";
-        final User user = new User("1234", email, "somename", Set.of(), Set.of());
+        final User user = new User("1234", email, "somename", false, Set.of(), Set.of());
         final Board board = buildBoard(2, EnumStateDto.VOTING, 10, user, Set.of(user), new HashSet<>());
         final BoardCard card = buildBoardCard(cardId, board, BoardCardsColumn.FAILURES, user, List.of());
         board.setBoardCards(Set.of(card));
@@ -584,7 +583,7 @@ class BoardCardServiceTest {
         // given
         final Integer cardId = 1;
         final String email = "test@example.com";
-        final User user = new User("1234", email, "somename", Set.of(), Set.of());
+        final User user = new User("1234", email, "somename", false, Set.of(), Set.of());
         final Board board = buildBoard(2, EnumStateDto.VOTING, 4, user, Set.of(user), new HashSet<>());
         final BoardCard card = buildBoardCard(cardId, board, BoardCardsColumn.FAILURES, user, List.of());
         board.setBoardCards(Set.of(card));
@@ -615,7 +614,7 @@ class BoardCardServiceTest {
     }
 
     private BoardCard buildBoardCard(final int id, final Board board, final BoardCardsColumn column, final User user,
-                                     List<BoardCardAction> actions) {
+                                     final List<BoardCardAction> actions) {
         return BoardCard.builder()
                 .id(id)
                 .board(board)

--- a/src/test/java/com/intive/patronage22/szczecin/retroboard/service/BoardServiceTest.java
+++ b/src/test/java/com/intive/patronage22/szczecin/retroboard/service/BoardServiceTest.java
@@ -79,9 +79,9 @@ class BoardServiceTest {
         //given
         final String uid = "1234";
         final String email = "John@test.pl";
-        final User user = new User(uid, email, "john14", Set.of(), Set.of());
-        final var board = buildBoard(10, EnumStateDto.CREATED, user, Set.of(), 0);
-        final var board1 = buildBoard(20, EnumStateDto.CREATED, user, Set.of(), 0);
+        final User user = new User(uid, email, "john14", false, Set.of(), Set.of());
+        final var board = TestUtils.buildBoard(10, EnumStateDto.CREATED, user, Set.of(), 0);
+        final var board1 = TestUtils.buildBoard(20, EnumStateDto.CREATED, user, Set.of(), 0);
         user.setUserBoards(Set.of(board, board1));
 
         //when
@@ -135,9 +135,9 @@ class BoardServiceTest {
         final String email = "Josef@test.pl";
         final String boardName = "My first board.";
 
-        final User user = new User(uid, email, "josef14", Set.of(), Set.of());
+        final User user = new User(uid, email, "josef14", false, Set.of(), Set.of());
 
-        final Board board = buildBoard(10, EnumStateDto.CREATED, user, Set.of(), 5);
+        final Board board = TestUtils.buildBoard(10, EnumStateDto.CREATED, user, Set.of(), 5);
 
         // when
         when(userRepository.findUserByEmail(email)).thenReturn(Optional.of(user));
@@ -184,7 +184,7 @@ class BoardServiceTest {
         final int boardId = 1;
         final String email = "testemail@example.com";
         final String displayName = "test";
-        final User user = new User("123", email, displayName, Set.of(),Set.of());
+        final User user = new User("123", email, displayName, false, Set.of(), Set.of());
 
         //when
         when(userRepository.findUserByEmail(email)).thenReturn(Optional.of(user));
@@ -201,9 +201,9 @@ class BoardServiceTest {
         final int boardId = 1;
         final String email = "testemail@example.com";
         final String displayName = "test12";
-        final User user = new User("123", email, displayName, Set.of(), Set.of());
-        final User assignUser = new User("1234", "assignUser@test.pl", "test1", Set.of(), Set.of());
-        final Board board = buildBoard(boardId, EnumStateDto.CREATED, user, Set.of(assignUser), 5);
+        final User user = new User("123", email, displayName, false, Set.of(), Set.of());
+        final User assignUser = new User("1234", "assignUser@test.pl", "test1", false, Set.of(), Set.of());
+        final Board board = TestUtils.buildBoard(boardId, EnumStateDto.CREATED, user, Set.of(assignUser), 5);
 
         //when
         when(userRepository.findUserByEmail(email)).thenReturn(Optional.of(user));
@@ -221,9 +221,9 @@ class BoardServiceTest {
         final int boardId = 1;
         final String email = "testemail@example.com";
         final String displayName = "testDisplayName";
-        final User user = new User("123", email, displayName, Set.of(), Set.of());
-        final User assignUser = new User("1234", "assignUser", "test1", Set.of(), Set.of());
-        final Board board = buildBoard(boardId, EnumStateDto.CREATED, user, Set.of(assignUser), 5);
+        final User user = new User("123", email, displayName, false, Set.of(), Set.of());
+        final User assignUser = new User("1234", "assignUser", "test1", false, Set.of(), Set.of());
+        final Board board = TestUtils.buildBoard(boardId, EnumStateDto.CREATED, user, Set.of(assignUser), 5);
         final BoardCard boardCard =new BoardCard
                 (2, board, "test card name", BoardCardsColumn.SUCCESS, user, List.of());
         final BoardCardAction boardCardAction = new BoardCardAction(4, boardCard, "test action");
@@ -274,7 +274,7 @@ class BoardServiceTest {
         final int boardId = 1;
         final String email = "testemail@example.com";
         final String displayName = "test";
-        final User user = new User("123", email, displayName, Set.of(),Set.of());
+        final User user = new User("123", email, displayName, false, Set.of(), Set.of());
 
         //when
         when(userRepository.findUserByEmail(email)).thenReturn(Optional.of(user));
@@ -291,9 +291,9 @@ class BoardServiceTest {
         final int boardId = 1;
         final String email = "testemail@example.com";
         final String displayName = "test12";
-        final User user = new User("123", email, displayName, Set.of(), Set.of());
-        final User assignUser = new User("1234", "assignUser@test.pl", "test1", Set.of(), Set.of());
-        final Board board = buildBoard(boardId, EnumStateDto.CREATED, user, Set.of(assignUser), 5);
+        final User user = new User("123", email, displayName, false, Set.of(), Set.of());
+        final User assignUser = new User("1234", "assignUser@test.pl", "test1", false, Set.of(), Set.of());
+        final Board board = TestUtils.buildBoard(boardId, EnumStateDto.CREATED, user, Set.of(assignUser), 5);
 
         //when
         when(userRepository.findUserByEmail(email)).thenReturn(Optional.of(user));
@@ -314,9 +314,9 @@ class BoardServiceTest {
         final String displayName = "testDisplayName";
         final int numberOfUserVotes = 2;
 
-        final User user = new User("123", userEmail, displayName, Set.of(), Set.of());
-        final User assignedUser = new User("1234", assignedUserEmail, displayName, Set.of(), Set.of());
-        final Board board = buildBoard(boardId, EnumStateDto.CREATED, user, Set.of(assignedUser), 5);
+        final User user = new User("123", userEmail, displayName, false, Set.of(), Set.of());
+        final User assignedUser = new User("1234", assignedUserEmail, displayName, false, Set.of(), Set.of());
+        final Board board = TestUtils.buildBoard(boardId, EnumStateDto.CREATED, user, Set.of(assignedUser), 5);
 
         final BoardCardAction successAction = new BoardCardAction(6, null, "happy");
         final BoardCardAction failureAction = new BoardCardAction(7, null, "help");
@@ -397,9 +397,9 @@ class BoardServiceTest {
         final String displayName = "testDisplayName";
         final int numberOfUserVotes = 2;
 
-        final User user = new User("123", userEmail, displayName, Set.of(), Set.of());
-        final User assignedUser = new User("1234", assignedUserEmail, displayName, Set.of(), Set.of());
-        final Board board = buildBoard(boardId, EnumStateDto.VOTING, user, Set.of(assignedUser), 5);
+        final User user = new User("123", userEmail, displayName, false, Set.of(), Set.of());
+        final User assignedUser = new User("1234", assignedUserEmail, displayName, false, Set.of(), Set.of());
+        final Board board = TestUtils.buildBoard(boardId, EnumStateDto.VOTING, user, Set.of(assignedUser), 5);
 
         final BoardCardAction successAction = new BoardCardAction(6, null, "happy");
         final BoardCardAction failureAction = new BoardCardAction(7, null, "help");
@@ -495,8 +495,8 @@ class BoardServiceTest {
         final String email = "username@test.pl";
         final int boardId = 1;
         final BoardCard boardCard = new BoardCard();
-        final User userOwner = new User(uidOwner, emailOwner, "displayName", Set.of(),Set.of());
-        final User user = new User(uid, email, "displayName", Set.of(),Set.of());
+        final User userOwner = new User(uidOwner, emailOwner, "displayName", false, Set.of(), Set.of());
+        final User user = new User(uid, email, "displayName", false, Set.of(), Set.of());
         final Board board = new Board(boardId, "board", 0,
                 EnumStateDto.CREATED, userOwner, Set.of(userOwner), Set.of(boardCard));
 
@@ -518,8 +518,8 @@ class BoardServiceTest {
         final String email = "username@test.pl";
         final int boardId = 1;
         final BoardCard boardCard = new BoardCard();
-        final User userOwner = new User(uidOwner, emailOwner, "displayName", Set.of(),Set.of());
-        final User user = new User(uid, email, "displayName", Set.of(), Set.of());
+        final User userOwner = new User(uidOwner, emailOwner, "displayName", false, Set.of(), Set.of());
+        final User user = new User(uid, email, "displayName", false, Set.of(), Set.of());
         final Board board = new Board
                 (boardId, "board", 0,
                         EnumStateDto.CREATED, userOwner, Set.of(userOwner), Set.of(boardCard));
@@ -551,8 +551,8 @@ class BoardServiceTest {
         // given
         final var uid = "uid101";
         final var email = "username@test.pl";
-        final var user = new User(uid, email, "displayName", Set.of(), Set.of());
-        final var board = buildBoard(10, EnumStateDto.CREATED, user, Set.of(),3);
+        final var user = new User(uid, email, "displayName", false, Set.of(), Set.of());
+        final var board = TestUtils.buildBoard(10, EnumStateDto.CREATED, user, Set.of(), 3);
         when(boardRepository.findById(board.getId())).thenReturn(Optional.of(board));
         final var boardPatchDto = new BoardPatchDto("testboard", 1500);
 
@@ -568,8 +568,8 @@ class BoardServiceTest {
         final var uid = "uid101";
         final var email = "username@test.pl";
         final var boardName = "My first board.";
-        final var userOwner = new User(uid, email, "displayName", Set.of(), Set.of());
-        final var board = buildBoard(10, EnumStateDto.CREATED, userOwner, Set.of(),3);
+        final var userOwner = new User(uid, email, "displayName", false, Set.of(), Set.of());
+        final var board = TestUtils.buildBoard(10, EnumStateDto.CREATED, userOwner, Set.of(), 3);
         final var boardPatchDto = new BoardPatchDto(boardName, 1500);
 
         // when
@@ -589,8 +589,8 @@ class BoardServiceTest {
         // given
         final var uid = "uid101";
         final var email = "username@test.pl";
-        final var user = new User(uid, email, "displayName", Set.of(), Set.of());
-        final var board = buildBoard(10, EnumStateDto.CREATED, user, Set.of(),3);
+        final var user = new User(uid, email, "displayName", false, Set.of(), Set.of());
+        final var board = TestUtils.buildBoard(10, EnumStateDto.CREATED, user, Set.of(), 3);
         final var boardPatchDto = new BoardPatchDto(null, 1500);
 
         // when
@@ -627,7 +627,7 @@ class BoardServiceTest {
         final int boardId = 1;
         final List<String> usersEmails = List.of();
         final String email = "testemail@example.com";
-        final User user = new User("123", email, "test name", Set.of(), Set.of());
+        final User user = new User("123", email, "test name", false, Set.of(), Set.of());
 
         //when
         when(userRepository.findUserByEmail(email)).thenReturn(Optional.of(user));
@@ -644,13 +644,13 @@ class BoardServiceTest {
         final int boardId = 1;
         final List<String> usersEmails = List.of();
         final String email = "testemail@example.com";
-        final User user = new User("123", email, "test name", Set.of(), Set.of());
-        final User boardOwner = new User("1234", "testemail1@example.com", "test name", Set.of(), Set.of());
+        final User user = new User("123", email, "test name", false, Set.of(), Set.of());
+        final User boardOwner = new User("1234", "testemail1@example.com", "test name", false, Set.of(), Set.of());
 
         //when
         when(userRepository.findUserByEmail(email)).thenReturn(Optional.of(user));
         when(boardRepository.findById(boardId))
-                .thenReturn(Optional.of(buildBoard(10, EnumStateDto.CREATED, boardOwner, Set.of(),3)));
+                .thenReturn(Optional.of(TestUtils.buildBoard(10, EnumStateDto.CREATED, boardOwner, Set.of(), 3)));
 
         //then
         assertThrows(BadRequestException.class, () -> boardService.assignUsersToBoard(boardId, usersEmails, email));
@@ -664,18 +664,18 @@ class BoardServiceTest {
         final List<String> usersEmails = List.of("testemail@example.com", "testfalseemail@example.com", "test@123.pl");
         final String ownerEmail = "owner@example.com";
         final String displayName = "testDisplayName";
-        final User owner = new User("123", ownerEmail, displayName, Set.of(), Set.of());
-        final User userToAssign = new User("126", usersEmails.get(0), displayName, new HashSet<>(), Set.of());
-        final User existingUser = new User("1234", "test@123.pl", displayName, new HashSet<>(), Set.of());
+        final User owner = new User("123", ownerEmail, displayName, false, Set.of(), Set.of());
+        final User userToAssign = new User("126", usersEmails.get(0), displayName, false, new HashSet<>(), Set.of());
+        final User existingUser = new User("1234", "test@123.pl", displayName, false, new HashSet<>(), Set.of());
         final Set<User> boardUsers = new HashSet<>(List.of(existingUser));
         final List<User> existingUsers = List.of(userToAssign, existingUser);
 
-        final Board board = buildBoard(10, EnumStateDto.CREATED, owner, boardUsers,3);
+        final Board board = TestUtils.buildBoard(10, EnumStateDto.CREATED, owner, boardUsers, 3);
 
         //when
         when(userRepository.findUserByEmail(ownerEmail)).thenReturn(Optional.of(owner));
         when(boardRepository.findById(boardId)).thenReturn(Optional.of(board));
-        when(userRepository.findAllByEmailIn(usersEmails)).thenReturn(existingUsers);
+        when(userRepository.findAllNotDeactivatedByEmailIn(usersEmails)).thenReturn(existingUsers);
         final JSONArray failedEmails = new JSONArray(boardService.assignUsersToBoard(boardId, usersEmails, ownerEmail));
 
         //then
@@ -698,8 +698,8 @@ class BoardServiceTest {
         // given
         final var uid = "1234";
         final var email = "John@test.pl";
-        final var user = new User(uid, email, "john14", Set.of(), Set.of());
-        final var board = buildBoard(10, EnumStateDto.VOTING, user, Set.of(),3);
+        final var user = new User(uid, email, "john14", false, Set.of(), Set.of());
+        final var board = TestUtils.buildBoard(10, EnumStateDto.VOTING, user, Set.of(), 3);
         final var boardPatchDto = new BoardPatchDto("testboard", 1500);
         when(userRepository.findUserByEmail(email)).thenReturn(Optional.of(user));
         when(boardRepository.findById(board.getId())).thenReturn(Optional.of(board));
@@ -714,8 +714,8 @@ class BoardServiceTest {
         // given
         final var uid = "1234";
         final var email = "John@test.pl";
-        final var user = new User(uid, email, "john14", Set.of(), Set.of());
-        final var board = buildBoard(10, EnumStateDto.CREATED, user, Set.of(),3);
+        final var user = new User(uid, email, "john14", false, Set.of(), Set.of());
+        final var board = TestUtils.buildBoard(10, EnumStateDto.CREATED, user, Set.of(), 3);
         final var boardPatchDto = new BoardPatchDto("testboard", 1500);
         when(userRepository.findUserByEmail(email)).thenReturn(Optional.of(user));
         when(boardRepository.findById(board.getId())).thenReturn(Optional.of(board));
@@ -735,10 +735,10 @@ class BoardServiceTest {
         final var email1 = "username@test.pl";
         final var uid2 = "uid102";
         final var email2 = "username2@test.pl";
-        final var user1 = new User(uid1, email1, "displayName1", Set.of(), Set.of());
-        final var user2 = new User(uid2, email2, "displayName2", Set.of(), Set.of());
-        final var boardCreated = buildBoard(10, EnumStateDto.CREATED, user1, Set.of(),3);
-        final var boardAssigned = buildBoard(11, EnumStateDto.CREATED, user2, Collections.singleton(user1),3);
+        final var user1 = new User(uid1, email1, "displayName1", false, Set.of(), Set.of());
+        final var user2 = new User(uid2, email2, "displayName2", false, Set.of(), Set.of());
+        final var boardCreated = TestUtils.buildBoard(10, EnumStateDto.CREATED, user1, Set.of(), 3);
+        final var boardAssigned = TestUtils.buildBoard(11, EnumStateDto.CREATED, user2, Collections.singleton(user1), 3);
         when(userRepository.findUserByEmail(email1)).thenReturn(Optional.of(user1));
         user1.setUserBoards(Collections.singleton(boardAssigned));
         user1.setCreatedBoards(Collections.singleton(boardCreated));
@@ -757,9 +757,9 @@ class BoardServiceTest {
         final String email = "boardOwner@test.pl";
         final Integer boardId = 10;
 
-        final User notAssignedUser = new User(uid, "test@test.com", "some_user", Set.of(), Set.of());
-        final User boardOwner = new User("123", email, "board_owner", Set.of(), Set.of());
-        final Board board = buildBoard(boardId, EnumStateDto.CREATED, boardOwner, Set.of(),3);
+        final User notAssignedUser = new User(uid, "test@test.com", "some_user", false, Set.of(), Set.of());
+        final User boardOwner = new User("123", email, "board_owner", false, Set.of(), Set.of());
+        final Board board = TestUtils.buildBoard(boardId, EnumStateDto.CREATED, boardOwner, Set.of(), 3);
 
         // when
         when(userRepository.findById(uid)).thenReturn(Optional.of(notAssignedUser));
@@ -779,9 +779,9 @@ class BoardServiceTest {
         final String email = "someUser@test.pl";
         final Integer boardId = 10;
 
-        final User notAssignedUser = new User(uid, email, "some_user", Set.of(), Set.of());
-        final User boardOwner = new User("123", "boardOwner@test.pl", "board_owner", Set.of(), Set.of());
-        final Board board = buildBoard(boardId, EnumStateDto.CREATED, boardOwner, Set.of(),3);
+        final User notAssignedUser = new User(uid, email, "some_user", false, Set.of(), Set.of());
+        final User boardOwner = new User("123", "boardOwner@test.pl", "board_owner", false, Set.of(), Set.of());
+        final Board board = TestUtils.buildBoard(boardId, EnumStateDto.CREATED, boardOwner, Set.of(), 3);
 
         // when
         when(userRepository.findById(uid)).thenReturn(Optional.of(notAssignedUser));
@@ -820,9 +820,9 @@ class BoardServiceTest {
         final String email = "currentlyLogged@test.pl";
         final Integer boardId = 10;
 
-        final User boardOwner = new User("123", "boardOwner@test1.com", "board_owner", Set.of(), Set.of());
-        final User userToRemove = new User(uid, "test3@test3.com", "userTest", Set.of(), Set.of());
-        final Board board = buildBoard(boardId, EnumStateDto.CREATED, boardOwner, Set.of(userToRemove),3);
+        final User boardOwner = new User("123", "boardOwner@test1.com", "board_owner", false, Set.of(), Set.of());
+        final User userToRemove = new User(uid, "test3@test3.com", "userTest", false, Set.of(), Set.of());
+        final Board board = TestUtils.buildBoard(boardId, EnumStateDto.CREATED, boardOwner, Set.of(userToRemove), 3);
 
         //when
         when(userRepository.findById(uid)).thenReturn(Optional.of(userToRemove));
@@ -844,8 +844,8 @@ class BoardServiceTest {
         final String email = "boardOwner@test1.com";
         final Integer boardId = 10;
 
-        final User boardOwner = new User(uid, email, "board_owner", Set.of(), Set.of());
-        final Board board = buildBoard(boardId, EnumStateDto.CREATED, boardOwner, Set.of(),3);
+        final User boardOwner = new User(uid, email, "board_owner", false, Set.of(), Set.of());
+        final Board board = TestUtils.buildBoard(boardId, EnumStateDto.CREATED, boardOwner, Set.of(), 3);
 
         //when
         when(userRepository.findById(uid)).thenReturn(Optional.of(boardOwner));
@@ -866,9 +866,9 @@ class BoardServiceTest {
         final String email = "boardOwner@test1.com";
         final Integer boardId = 10;
 
-        final User boardOwner = new User("12345", email, "board_owner", Set.of(), Set.of());
-        final User userToRemove = new User(uid, "test2@test2.com", "userTest", Set.of(), Set.of());
-        final Board board = buildBoard(boardId, EnumStateDto.CREATED, boardOwner, new HashSet<>(),3);
+        final User boardOwner = new User("12345", email, "board_owner", false, Set.of(), Set.of());
+        final User userToRemove = new User(uid, "test2@test2.com", "userTest", false, Set.of(), Set.of());
+        final Board board = TestUtils.buildBoard(boardId, EnumStateDto.CREATED, boardOwner, new HashSet<>(), 3);
         board.getUsers().add(userToRemove);
 
         //when
@@ -891,9 +891,9 @@ class BoardServiceTest {
         final String email = "currentlyLogged@test.pl";
         final Integer boardId = 10;
 
-        final User boardOwner = new User("12345", "boardOwner@test1.com", "board_owner", Set.of(), Set.of());
-        final User currentlyLogged = new User(uid, email, "currently_logged", Set.of(), Set.of());
-        final Board board = buildBoard(boardId, EnumStateDto.CREATED, boardOwner, new HashSet<>(),3);
+        final User boardOwner = new User("12345", "boardOwner@test1.com", "board_owner", false, Set.of(), Set.of());
+        final User currentlyLogged = new User(uid, email, "currently_logged", false, Set.of(), Set.of());
+        final Board board = TestUtils.buildBoard(boardId, EnumStateDto.CREATED, boardOwner, new HashSet<>(), 3);
         board.getUsers().add(currentlyLogged);
 
         //when
@@ -910,12 +910,12 @@ class BoardServiceTest {
 
     @Test
     @DisplayName("When setNextState is called - it will change state from CREATED to VOTING (next) and return board details.")
-    void setNextStateChangeStateValueAndSaveTheData()  {
+    void setNextStateChangeStateValueAndSaveTheData() {
         // given
         final var uid = "uid101";
         final var email = "username@test.pl";
-        final var user = new User(uid, email, "displayName", Set.of(), Set.of());
-        final var board = buildBoard(10, EnumStateDto.CREATED, user, Set.of(), 3);
+        final var user = new User(uid, email, "displayName", false, Set.of(), Set.of());
+        final var board = TestUtils.buildBoard(10, EnumStateDto.CREATED, user, Set.of(), 3);
         when(boardRepository.save(any(Board.class))).thenReturn(board);
         when(boardRepository.findById(board.getId())).thenReturn(Optional.of(board));
         when(userRepository.findUserByEmail(email)).thenReturn(Optional.of(user));
@@ -935,15 +935,15 @@ class BoardServiceTest {
         // given
         final var uid = "uid101";
         final var email = "username@test.pl";
-        final var user = new User(uid, email, "displayName", Set.of(), Set.of());
-        final var board = buildBoard(10,EnumStateDto.DONE, user, Set.of(), 3);
+        final var user = new User(uid, email, "displayName", false, Set.of(), Set.of());
+        final var board = TestUtils.buildBoard(10, EnumStateDto.DONE, user, Set.of(), 3);
         when(boardRepository.save(any(Board.class))).thenReturn(board);
         when(boardRepository.findById(board.getId())).thenReturn(Optional.of(board));
         when(userRepository.findUserByEmail(email)).thenReturn(Optional.of(user));
 
         // when
         final NotAcceptableException exception = assertThrows(
-                NotAcceptableException.class, () -> boardService.setNextState(board.getId(),email));
+                NotAcceptableException.class, () -> boardService.setNextState(board.getId(), email));
 
         // then
         assertEquals("Already in last state", exception.getMessage());
@@ -955,7 +955,7 @@ class BoardServiceTest {
         // given
         final var uid = "uid101";
         final var email = "username@test.pl";
-        final var user = new User(uid, email, "displayName", Set.of(), Set.of());
+        final var user = new User(uid, email, "displayName", false, Set.of(), Set.of());
         final var board_id = 1;
         when(userRepository.findUserByEmail(email)).thenReturn(Optional.of(user));
         when(boardRepository.findById(board_id)).thenReturn(Optional.empty());
@@ -976,15 +976,15 @@ class BoardServiceTest {
         final var email1 = "username1@test.pl";
         final var uid2 = "uid102";
         final var email2 = "username2@test.pl";
-        final var owner = new User(uid1, email1, "displayName", Set.of(), Set.of());
-        final var user = new User(uid2, email2, "displayName2", Set.of(), Set.of());
-        final var board = buildBoard(10, EnumStateDto.CREATED, owner, Set.of(), 3);
+        final var owner = new User(uid1, email1, "displayName", false, Set.of(), Set.of());
+        final var user = new User(uid2, email2, "displayName2", false, Set.of(), Set.of());
+        final var board = TestUtils.buildBoard(10, EnumStateDto.CREATED, owner, Set.of(), 3);
         when(boardRepository.findById(board.getId())).thenReturn(Optional.of(board));
         when(userRepository.findUserByEmail(email2)).thenReturn(Optional.of(user));
 
         // when
         final NotFoundException exception = assertThrows(
-                NotFoundException.class, () -> boardService.setNextState(board.getId(),email2));
+                NotFoundException.class, () -> boardService.setNextState(board.getId(), email2));
 
         // then
         assertEquals("User is not the board owner.", exception.getMessage());
@@ -996,28 +996,17 @@ class BoardServiceTest {
         // given
         final var uid = "uid101";
         final var email = "username@test.pl";
-        final var user = new User(uid, email, "displayName", Set.of(), Set.of());
-        final var board = buildBoard(10,EnumStateDto.CREATED, user, Set.of(),0);
+        final var user = new User(uid, email, "displayName", false, Set.of(), Set.of());
+        final var board = TestUtils.buildBoard(10, EnumStateDto.CREATED, user, Set.of(), 0);
         when(boardRepository.save(any(Board.class))).thenReturn(board);
         when(boardRepository.findById(board.getId())).thenReturn(Optional.of(board));
         when(userRepository.findUserByEmail(email)).thenReturn(Optional.of(user));
 
         // when
         final BadRequestException exception = assertThrows(
-                BadRequestException.class, () -> boardService.setNextState(board.getId(),email));
+                BadRequestException.class, () -> boardService.setNextState(board.getId(), email));
 
         // then
         assertEquals("Number of votes not set!", exception.getMessage());
-    }
-
-    private Board buildBoard(final int id, final EnumStateDto state, final User user, final Set<User> users, final Integer maximumNumberOfVotes) {
-        return Board.builder()
-                .id(id)
-                .name("My first board.")
-                .state(state)
-                .creator(user)
-                .users(users)
-                .maximumNumberOfVotes(maximumNumberOfVotes)
-                .build();
     }
 }

--- a/src/test/java/com/intive/patronage22/szczecin/retroboard/service/SynchronizeWithFirebaseSchedulerTest.java
+++ b/src/test/java/com/intive/patronage22/szczecin/retroboard/service/SynchronizeWithFirebaseSchedulerTest.java
@@ -6,8 +6,12 @@ import com.google.firebase.auth.FirebaseAuthException;
 import com.google.firebase.auth.ListUsersPage;
 import com.google.firebase.auth.UserMetadata;
 import com.google.firebase.auth.UserRecord;
+import com.intive.patronage22.szczecin.retroboard.dto.EnumStateDto;
+import com.intive.patronage22.szczecin.retroboard.model.Board;
 import com.intive.patronage22.szczecin.retroboard.model.User;
+import com.intive.patronage22.szczecin.retroboard.repository.BoardRepository;
 import com.intive.patronage22.szczecin.retroboard.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -16,16 +20,18 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -40,10 +46,13 @@ class SynchronizeWithFirebaseSchedulerTest {
     private UserRepository userRepository;
 
     @MockBean
+    private BoardRepository boardRepository;
+
+    @MockBean
     private FirebaseAuth firebaseAuth;
 
     @Test
-    void synchronizeUsersShouldNotPersistToTheDatabaseWhenThereAreNoUsersInFirebase() throws FirebaseAuthException {
+    void synchronizeUsersShouldNotPersistUserToTheDatabaseWhenThereAreNoUsersInFirebase() throws FirebaseAuthException {
         // given
         final ListUsersPage listUsersPage = mock(ListUsersPage.class);
         final List<ExportedUserRecord> firebaseUsers = Collections.emptyList();
@@ -57,43 +66,49 @@ class SynchronizeWithFirebaseSchedulerTest {
         synchronizeWithFirebaseScheduler.synchronizeUsers();
 
         @SuppressWarnings("unchecked") final ArgumentCaptor<List<User>> captor = ArgumentCaptor.forClass(List.class);
-        verify(userRepository).saveAll(captor.capture());
+        verify(userRepository, times(2)).saveAll(captor.capture());
 
         final List<String> capturedEmails = captor.getValue().stream().map(User::getEmail).collect(Collectors.toList());
         assertEquals(0, capturedEmails.size());
     }
 
     @Test
-    void synchronizeUsersShouldNotPersistToTheDatabaseWhenThereAreNoNewNotSignedInUsers() throws FirebaseAuthException {
+    void synchronizeUsersShouldNotPersistToTheDatabaseWhenThereAreNoNewNotRegisteredUsers() throws FirebaseAuthException {
         // given
         final ListUsersPage listUsersPage = mock(ListUsersPage.class);
 
         final ExportedUserRecord mockUser1 = mockUser(0L, "uid1", "test1@test.pl", "test1");
         final ExportedUserRecord mockUser2 = mockUser(657521L, "uid2", "test2@test.pl", "test2");
         final ExportedUserRecord mockUser3 = mockUser(654654L, "uid3", "test3@test.pl", "test3");
-        final ExportedUserRecord mockUser4 = mockUser(165465465468L, "uid3", "test3@test.pl", "test3");
+        final ExportedUserRecord mockUser4 = mockUser(165465465468L, "uid4", "test4@test.pl", "test4");
         final List<ExportedUserRecord> mockUsers = List.of(mockUser1, mockUser2, mockUser3, mockUser4);
 
         final User userDb1 = createUser("uid1", "test1@test.pl", "test1");
-        final List<User> usersDb = List.of(userDb1);
+        final User userDb2 = createUser("uid2", "test2@test.pl", "test2");
+        final User userDb3 = createUser("uid3", "test3@test.pl", "test3");
+        final User userDb4 = createUser("uid4", "test4@test.pl", "test4");
+        final List<User> usersDb = List.of(userDb1, userDb2, userDb3, userDb4);
 
         // when
         when(firebaseAuth.listUsers(null, 20)).thenReturn(listUsersPage);
         when(listUsersPage.iterateAll()).thenReturn(mockUsers);
         when(userRepository.findAllByEmailIn(any())).thenReturn(usersDb);
+        when(userRepository.findAllByEmailNotIn(any())).thenReturn(Collections.emptyList());
 
         // then
         synchronizeWithFirebaseScheduler.synchronizeUsers();
 
-        @SuppressWarnings("unchecked") final ArgumentCaptor<List<User>> captor = ArgumentCaptor.forClass(List.class);
-        verify(userRepository).saveAll(captor.capture());
+        @SuppressWarnings("unchecked") final ArgumentCaptor<List<User>> usersToSaveCaptor = ArgumentCaptor.forClass(List.class);
+        verify(userRepository, times(2)).saveAll(usersToSaveCaptor.capture());
 
-        final List<String> capturedEmails = captor.getValue().stream().map(User::getEmail).collect(Collectors.toList());
+        final List<String> capturedEmails = usersToSaveCaptor.getValue().stream().map(User::getEmail).collect(Collectors.toList());
         assertEquals(0, capturedEmails.size());
     }
 
     @Test
-    void synchronizeUsersShouldPersistToTheDatabaseWhenThereAreNewNotSignedInUsers() throws FirebaseAuthException {
+    @DisplayName("synchronize should persist new registered Users in Firebase to the database - those who have not " +
+            "logged in yet and those who have already logged in but don't exist in the database")
+    void synchronizeUsersShouldPersistToTheDatabaseNewRegisteredUsers() throws FirebaseAuthException {
         // given
         final ListUsersPage listUsersPage = mock(ListUsersPage.class);
 
@@ -107,21 +122,182 @@ class SynchronizeWithFirebaseSchedulerTest {
         when(firebaseAuth.listUsers(null, 20)).thenReturn(listUsersPage);
         when(listUsersPage.iterateAll()).thenReturn(mockUsers);
         when(userRepository.findAllByEmailIn(any())).thenReturn(Collections.emptyList());
+        when(userRepository.findAllByEmailNotIn(any())).thenReturn(Collections.emptyList());
 
         // then
         synchronizeWithFirebaseScheduler.synchronizeUsers();
 
         @SuppressWarnings("unchecked") final ArgumentCaptor<List<User>> captor = ArgumentCaptor.forClass(List.class);
-        verify(userRepository).saveAll(captor.capture());
-        final List<String> capturedEmails = captor.getValue().stream().map(User::getEmail).collect(Collectors.toList());
+        verify(userRepository, times(2)).saveAll(captor.capture());
+        final List<String> capturedEmails = captor.getAllValues()
+                .stream()
+                .flatMap(Collection::stream)
+                .map(User::getEmail)
+                .collect(Collectors.toList());
 
         final List<String> firebaseUsersEmails = firebaseUsersEmails(mockUsers);
-        assertNotEquals(firebaseUsersEmails, capturedEmails);
-        assertEquals(3, capturedEmails.size());
+        assertEquals(firebaseUsersEmails, capturedEmails);
+        assertEquals(4, capturedEmails.size());
         assertTrue(capturedEmails.contains("test1@test.pl"));
         assertTrue(capturedEmails.contains("test2@test.pl"));
         assertTrue(capturedEmails.contains("test3@test.pl"));
-        assertFalse(capturedEmails.contains("test4@test.pl"));
+        assertTrue(capturedEmails.contains("test4@test.pl"));
+    }
+
+    @Test
+    @DisplayName("synchronize should remove User when he is neither a Board creator nor assigned to the Boards " +
+            "and ignore the one that has Boards assigned")
+    @SuppressWarnings("unchecked")
+    void synchronizeShouldRemoveUserWhenHeIsNeitherABoardCreatorNorAssignedToTheBoards() throws FirebaseAuthException {
+        // given
+        final ListUsersPage listUsersPage = mock(ListUsersPage.class);
+        final ExportedUserRecord firebaseUser = mockUser(0L, "uid1", "test1@test.pl", "test1");
+        final List<ExportedUserRecord> firebaseUsers = List.of(firebaseUser);
+        final List<String> firebaseUsersEmails = firebaseUsersEmails(firebaseUsers);
+
+        final User userExistingInFirebase = createUser("uid1", "test1@test.pl", "test1");
+        final User userDeletedInFirebase = createUser("uid2", "test2@test.pl", "test2");
+        final List<User> usersDb = List.of(userExistingInFirebase);
+
+        // when
+        when(firebaseAuth.listUsers(null, 20)).thenReturn(listUsersPage);
+        when(listUsersPage.iterateAll()).thenReturn(firebaseUsers);
+        when(userRepository.findAllByEmailIn(firebaseUsersEmails)).thenReturn(usersDb);
+        when(userRepository.findAllByEmailNotIn(firebaseUsersEmails)).thenReturn(List.of(userDeletedInFirebase));
+
+        //then
+        synchronizeWithFirebaseScheduler.synchronizeUsers();
+
+        final ArgumentCaptor<List<User>> usersCaptor = ArgumentCaptor.forClass(List.class);
+        verify(userRepository, times(2)).saveAll(usersCaptor.capture());
+        final List<User> savedUsers = usersCaptor.getValue();
+        assertEquals(0, savedUsers.size());
+
+        verify(userRepository).deleteAll(usersCaptor.capture());
+        final List<User> deletedUsers = usersCaptor.getValue();
+        assertEquals(1, deletedUsers.size());
+        assertTrue(deletedUsers.contains(userDeletedInFirebase));
+
+        final ArgumentCaptor<List<Board>> boardCaptor = ArgumentCaptor.forClass(List.class);
+        verify(boardRepository, times(2)).deleteAll(boardCaptor.capture());
+        final List<Board> deletedBoards = boardCaptor.getAllValues()
+                .stream()
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
+
+        assertEquals(0, deletedBoards.size());
+    }
+
+    @Test
+    @DisplayName("synchronize should remove Users and Boards they have created when they have no Boards assigned")
+    @SuppressWarnings("unchecked")
+    void synchronizeShouldRemoveUserAndBoardHeCreated() throws FirebaseAuthException {
+        // given
+        final ListUsersPage listUsersPage = mock(ListUsersPage.class);
+        final ExportedUserRecord firebaseUser1 = mockUser(0L, "uid1", "test1@test.pl", "test1");
+        final ExportedUserRecord firebaseUser2 = mockUser(0L, "uid3", "test3@test.pl", "test3");
+        final List<ExportedUserRecord> firebaseUsers = List.of(firebaseUser1, firebaseUser2);
+        final List<String> firebaseUsersEmails = firebaseUsersEmails(firebaseUsers);
+
+        final User userExistingInFirebase1 = createUser("uid1", "test1@test.pl", "test1");
+        final User userExistingInFirebase2 = createUser("uid3", "test3@test.pl", "test3");
+        final List<User> usersDb = List.of(userExistingInFirebase1, userExistingInFirebase2);
+
+        final User userDeletedInFirebase1 = createUser("uid2", "test2@test.pl", "test2");
+        final User userDeletedInFirebase2 = createUser("uid4", "test4@test.pl", "test4");
+        final Board board1 = TestUtils.buildBoard(1, EnumStateDto.CREATED, userDeletedInFirebase1, new HashSet<>(), 3);
+        final Board board2 = TestUtils.buildBoard(2, EnumStateDto.CREATED, userDeletedInFirebase2, new HashSet<>(), 3);
+        userDeletedInFirebase1.getCreatedBoards().add(board1);
+        userDeletedInFirebase2.getCreatedBoards().add(board2);
+
+        // when
+        when(firebaseAuth.listUsers(null, 20)).thenReturn(listUsersPage);
+        when(listUsersPage.iterateAll()).thenReturn(firebaseUsers);
+        when(userRepository.findAllByEmailIn(firebaseUsersEmails)).thenReturn(usersDb);
+        when(userRepository.findAllByEmailNotIn(firebaseUsersEmails))
+                .thenReturn(List.of(userDeletedInFirebase1, userDeletedInFirebase2));
+
+        //then
+        synchronizeWithFirebaseScheduler.synchronizeUsers();
+
+        final ArgumentCaptor<List<User>> usersCaptor = ArgumentCaptor.forClass(List.class);
+        verify(userRepository, times(2)).saveAll(usersCaptor.capture());
+        final List<User> capturedUsers = usersCaptor.getValue();
+        assertEquals(0, capturedUsers.size());
+
+        verify(userRepository).deleteAll(usersCaptor.capture());
+        final List<User> deletedUsers = usersCaptor.getValue();
+        assertEquals(2, deletedUsers.size());
+        assertTrue(deletedUsers.contains(userDeletedInFirebase1));
+
+        final ArgumentCaptor<List<Board>> boardCaptor = ArgumentCaptor.forClass(List.class);
+        verify(boardRepository, times(2)).deleteAll(boardCaptor.capture());
+        final List<Board> deletedBoards = boardCaptor.getAllValues()
+                .stream()
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
+
+        assertEquals(2, deletedBoards.size());
+        assertTrue(deletedBoards.contains(board1));
+        assertTrue(deletedBoards.contains(board2));
+    }
+
+    @Test
+    @DisplayName("synchronize should deactivate User when he is assigned to the Board and delete the Boards he created")
+    @SuppressWarnings("unchecked")
+    void synchronizeShouldDeactivateUserAndDeleteBoard() throws FirebaseAuthException {
+        // given
+        final ListUsersPage listUsersPage = mock(ListUsersPage.class);
+        final ExportedUserRecord firebaseUser1 = mockUser(0L, "uid1", "test1@test.pl", "test1");
+        final ExportedUserRecord firebaseUser2 = mockUser(0L, "uid3", "test3@test.pl", "test3");
+        final List<ExportedUserRecord> firebaseUsers = List.of(firebaseUser1, firebaseUser2);
+        final List<String> firebaseUsersEmails = firebaseUsersEmails(firebaseUsers);
+
+        final User userExistingInFirebase1 = createUser("uid1", "test1@test.pl", "test1");
+        final User userExistingInFirebase2 = createUser("uid3", "test3@test.pl", "test3");
+        final List<User> usersDb = List.of(userExistingInFirebase1, userExistingInFirebase2);
+
+        final User userDeletedInFirebase1 = createUser("uid2", "test2@test.pl", "test2");
+        final User boardOwner = createUser("uid4", "test4@test.pl", "test4");
+        final Board board1 = TestUtils.buildBoard(1, EnumStateDto.CREATED, boardOwner, new HashSet<>(), 3);
+        final Board board2 = TestUtils.buildBoard(2, EnumStateDto.CREATED, userDeletedInFirebase1, new HashSet<>(), 3);
+        userDeletedInFirebase1.getUserBoards().add(board1);
+        userDeletedInFirebase1.getCreatedBoards().add(board2);
+
+        // when
+        when(firebaseAuth.listUsers(null, 20)).thenReturn(listUsersPage);
+        when(listUsersPage.iterateAll()).thenReturn(firebaseUsers);
+        when(userRepository.findAllByEmailIn(firebaseUsersEmails)).thenReturn(usersDb);
+        when(userRepository.findAllByEmailNotIn(firebaseUsersEmails)).thenReturn(List.of(userDeletedInFirebase1));
+
+        //then
+        synchronizeWithFirebaseScheduler.synchronizeUsers();
+
+        final ArgumentCaptor<List<User>> usersCaptor = ArgumentCaptor.forClass(List.class);
+        verify(userRepository, times(2)).saveAll(usersCaptor.capture());
+        final List<User> updatedUsers = usersCaptor.getAllValues()
+                .stream()
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
+
+        assertEquals(1, updatedUsers.size());
+        assertTrue(updatedUsers.get(0).isDeleted());
+
+        verify(userRepository).deleteAll(usersCaptor.capture());
+        final List<User> deletedUsers = usersCaptor.getValue();
+        assertEquals(0, deletedUsers.size());
+        assertFalse(deletedUsers.contains(userDeletedInFirebase1));
+
+        final ArgumentCaptor<List<Board>> boardCaptor = ArgumentCaptor.forClass(List.class);
+        verify(boardRepository, times(2)).deleteAll(boardCaptor.capture());
+        final List<Board> deletedBoards = boardCaptor.getAllValues()
+                .stream()
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
+
+        assertEquals(1, deletedBoards.size());
+        assertTrue(deletedBoards.contains(board2));
+        assertFalse(deletedBoards.contains(board1));
     }
 
     private ExportedUserRecord mockUser(final long lastSignInTimestamp, final String uid, final String email,
@@ -145,6 +321,9 @@ class SynchronizeWithFirebaseSchedulerTest {
                 .uid(uid)
                 .email(email)
                 .displayName(displayName)
+                .deleted(false)
+                .userBoards(new HashSet<>())
+                .createdBoards(new HashSet<>())
                 .build();
     }
 

--- a/src/test/java/com/intive/patronage22/szczecin/retroboard/service/TestUtils.java
+++ b/src/test/java/com/intive/patronage22/szczecin/retroboard/service/TestUtils.java
@@ -1,0 +1,21 @@
+package com.intive.patronage22.szczecin.retroboard.service;
+
+import com.intive.patronage22.szczecin.retroboard.dto.EnumStateDto;
+import com.intive.patronage22.szczecin.retroboard.model.Board;
+import com.intive.patronage22.szczecin.retroboard.model.User;
+
+import java.util.Set;
+
+public class TestUtils {
+
+    public static Board buildBoard(final int id, final EnumStateDto state, final User user, final Set<User> users, final Integer maximumNumberOfVotes) {
+        return Board.builder()
+                .id(id)
+                .name("My first board.")
+                .state(state)
+                .creator(user)
+                .users(users)
+                .maximumNumberOfVotes(maximumNumberOfVotes)
+                .build();
+    }
+}


### PR DESCRIPTION
[P2022-1883](https://tracker.intive.com/jira/browse/P2022-1883) Full synchronization of firebase users.

**This Scheduler should:**
1. Add all new Firebase `User`s to our db
2. Delete `User` and `Board`s he created from db if 
- was deleted in Firebase
- has no `Board`s assigned
3. Deactivate `User` (set flag `deleted = true`) and delete `Board`s he created from db if 
- was deleted in Firebase
- has `Board`s assigned


**What has been done:**
- created new class `TestUtils` and moved there method `buildBoard()` from `BoardServiceTest`, because we need it also in `SynchronizeWithFirebaseSchedulerTest`
- added new changelog, added new column `deleted` in `retro.user_data`
- added new method `findAllNotDeactivatedByEmailIn` that prevents deactivated User from not to be assigned to any Board
- updated `SynchronizeWithFirebaseScheduler`, added new tests